### PR TITLE
Add GV View table borders

### DIFF
--- a/src/gv/L2/templates/l2.html
+++ b/src/gv/L2/templates/l2.html
@@ -182,13 +182,13 @@
                     <tr>
                         <th>Show</th>
                         <th>Package</th>
-                        <th>Count</th>
+                        <th>#</th>
                     </thead>
                     <tfoot>
                     <tr>
                         <th>Show</th>
                         <th>Package</th>
-                        <th>Count</th>
+                        <th>#</th>
                     </tr>
                     </tfoot>
                     <tbody>
@@ -199,19 +199,19 @@
                     <tr>
                         <th rowspan="2">Show</th>
                         <th rowspan="2">Package</th>
-                        <th colspan="2">Count</th>
+                        <th colspan="2">#</th>
                     </tr>
                     <tr>
-                        <th>Exact</th>
-                        <th>Similar</th>
+                        <th title="Exact">E</th>
+                        <th title="Similar">S</th>
                     </tr>
                     </thead>
                     <tfoot>
                     <tr>
                         <th>Show</th>
                         <th>Package</th>
-                        <th>Exact</th>
-                        <th>Similar</th>
+                        <th title="Exact">E</th>
+                        <th title="Similar">S</th>
                     </tr>
                     </tfoot>
                     <tbody>

--- a/src/static/css/l2.css
+++ b/src/static/css/l2.css
@@ -117,6 +117,10 @@ width: 100%;
     text-align: right;
 }
 
+.center-justified{
+    text-align: center;
+}
+
 .select2-container--default .select2-results>.select2-results__options{
 	max-height: 500px;
 }
@@ -133,4 +137,24 @@ width: 100%;
 .l2_stix2_span_key{
 	font-weight: bold;
 	background-color: yellow;
+}
+
+#related-package-table,
+#related-package-similar-table{
+    border-collapse: collapse !important;
+}
+#related-package-table td,
+#related-package-table th,
+#related-package-similar-table td,
+#related-package-similar-table th{
+    border: solid 1px #999999;
+    width: initial !important;
+}
+
+table.dataTable thead .sorting:after, 
+table.dataTable thead .sorting_asc:after, 
+table.dataTable thead .sorting_desc:after, 
+table.dataTable thead .sorting_asc_disabled:after, 
+table.dataTable thead .sorting_desc_disabled:after {
+    bottom: 0;
 }

--- a/src/static/js/l2.js
+++ b/src/static/js/l2.js
@@ -521,16 +521,16 @@ $(function(){
         		//ipv4 と domain の similarity の合算を表示
         		var similar = simlar_info['ipv4']  + simlar_info['domain'];
         		tr = $('<tr></tr>')
-                		.append($('<td></td>')
+                		.append($('<td class="center-justified"></td>')
                         .append($('<input type="checkbox">').attr('value',package_id).attr('class','related-package-similar-checkbox')))
                         .append($('<td></td>').text(package_name))
                         .append($('<td class="right-justified"></td>').text(exact))
                         .append($('<td class="right-justified"></td>').text(similar))
-                table.row.add(tr);
+                //table.row.add(tr);
         	}
         	else{
         		tr = $('<tr></tr>')
-    				.append($('<td></td>')
+    				.append($('<td class="center-justified"></td>')
     				.append($('<input type="checkbox">').attr('value',package_id).attr('class','related-package-checkbox')))
     				.append($('<td></td>').text(package_name))
     				.append($('<td  class="right-justified"></td>').text(exact));


### PR DESCRIPTION
GV Related CTI 画面のTable border line 表示対応
- テーブルの罫線を追加
- 列の幅調整
- 列名変更（Count→#、Exact→E、Similar→S）
- Sortアイコンの位置調整