### PR TITLE
Draw a graph by an object_id

### DIFF
--- a/src/core/api/rs.py
+++ b/src/core/api/rs.py
@@ -218,6 +218,13 @@ class Ctirs(object):
         # ajax呼び出し
         return self._call_post_ctirs_api(url, params, json=j)
 
+    def get_bundle_from_object_id(self, object_id):
+        params = {
+            'match[object_id]': object_id
+        }
+        url = '/api/v1/stix_files_v2/search_bundle'
+        return self._call_get_ctirs_api(url, params)
+
     # ajax呼び出し(get)
     def _call_get_ctirs_api(self, url_suffix, params):
         # 共通呼び出し


### PR DESCRIPTION
For the #53 .

S-TIP should be able to draw a Graph not only by a package_id but also object_id.

I add an query item (object_id).
If an user specifies an object_id instead of a package_id, S-TIP searches a package which contains the object_id and draw it.
If a package_id and an object_id are specified at the same time, S-TIP draws a graph by the package_id.

---

S-TIP の Graph View は package_id を指定して描画することができます (S-TIP SNS の GV link クリック時の挙動)。
これを object_id 指定でも描画可能とします。
query item として object_id を準備します。object_id が指定された場合は、S-TIP は object_id が含まれる
package を精査して、その package のグラフを描画します。
同時に指定された場合は従来通り package_id の指定を優先します。

