### PR TITLE
Fixed an issue about invalid relationship

### DIFF
--- a/src/gv/L2/ajax/views.py
+++ b/src/gv/L2/ajax/views.py
@@ -869,6 +869,7 @@ def set_alchemy_node_identity(aj, object_, an_package_id):
     an = AlchemyNode(node_id, 'v2_identity', title, description, cluster=an_package_id)
     an.set_stix2_object(object_)
     aj.add_json_node(an)
+    set_created_by_ref_edge(aj, object_)
     return
 
 


### PR DESCRIPTION
Issue about s-tip/stip-sns#138 .

In GraphView page, I modified to add a link between each identity object which is related by the `created_by_ref` property.
